### PR TITLE
Improve publish function option types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logsnag",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "LogSnag Client",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/logsnag.ts
+++ b/src/client/logsnag.ts
@@ -1,14 +1,21 @@
 import fetch from 'node-fetch';
 import { LOGSNAG_ENDPOINT } from '../constants';
 import { HTTPResponseError } from './error';
-import { PublishOptions } from '../types';
+
+import type { ClientGenerics, ClientOptions, PublishOptions } from '../types';
 
 /**
  * LogSnag Client
  */
-export default class LogSnag {
+export default class LogSnag<
+  TOptions extends Partial<ClientGenerics> = {
+    channel: string;
+    event: string;
+    project: string;
+  }
+> {
   private readonly token: string;
-  private readonly project: string;
+  private readonly project: TOptions['project'];
 
   /**
    * Construct a new LogSnag instance
@@ -16,7 +23,7 @@ export default class LogSnag {
    * @param project LogSnag project name
    * for more information, see: docs.logsnag.com
    */
-  constructor({ token, project }: { token: string; project: string }) {
+  constructor({ token, project }: ClientOptions<TOptions['project']>) {
     this.token = token;
     this.project = project;
   }
@@ -25,7 +32,7 @@ export default class LogSnag {
    * Get project name
    * @returns project name
    */
-  getProject(): string {
+  getProject(): TOptions['project'] {
     return this.project;
   }
 
@@ -42,9 +49,7 @@ export default class LogSnag {
    * @param options
    * @returns true when successfully published
    */
-  public async publish<TProject = string, TChannel = string, TEvent = string>(
-    options: PublishOptions<TProject, TChannel, TEvent>
-  ): Promise<boolean> {
+  public async publish(options: PublishOptions<TOptions>): Promise<boolean> {
     const headers = {
       'Content-Type': 'application/json',
       Authorization: this.createAuthorizationHeader()

--- a/src/client/logsnag.ts
+++ b/src/client/logsnag.ts
@@ -30,7 +30,9 @@ export default class LogSnag {
    * @param options
    * @returns true when successfully published
    */
-  public async publish(options: PublishOptions): Promise<boolean> {
+  public async publish<TProject = string, TChannel = string, TEvent = string>(
+    options: PublishOptions<TProject, TChannel, TEvent>
+  ): Promise<boolean> {
     const headers = {
       'Content-Type': 'application/json',
       Authorization: this.createAuthorizationHeader()

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,0 +1,10 @@
+export interface ClientOptions<TProject = string> {
+  token: string;
+  project: TProject;
+}
+
+export interface ClientGenerics {
+  channel?: string;
+  event?: string;
+  project?: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
-export * from './publish'
+export * from './client';
+export * from './publish';

--- a/src/types/publish.ts
+++ b/src/types/publish.ts
@@ -9,18 +9,11 @@ export type Tags = Record<string, string | number | boolean>;
  * Options for publishing LogSnag events
  */
 export interface PublishOptions<
-  TOptions extends ClientGenerics = {
+  TOptions extends Omit<ClientGenerics, 'project'> = {
     channel: string;
     event: string;
-    project: string;
   }
 > {
-  /**
-   * Project name
-   * example: "my-saas"
-   */
-  project?: TOptions['project'];
-
   /**
    * Channel name
    * example: "waitlist"

--- a/src/types/publish.ts
+++ b/src/types/publish.ts
@@ -1,28 +1,37 @@
+import type { ClientGenerics } from '.';
 
-/** Tag Type **/
-export type Tags = { [key: string]: string | number | boolean };
+/**
+ * Tag Type
+ */
+export type Tags = Record<string, string | number | boolean>;
 
 /**
  * Options for publishing LogSnag events
  */
-export interface PublishOptions <TProject = string, TChannel = string, TEvent = string> {
+export interface PublishOptions<
+  TOptions extends ClientGenerics = {
+    channel: string;
+    event: string;
+    project: string;
+  }
+> {
   /**
    * Project name
    * example: "my-saas"
    */
-  project: TProject;
+  project?: TOptions['project'];
 
   /**
    * Channel name
    * example: "waitlist"
    */
-  channel: TChannel;
+  channel: TOptions['channel'];
 
   /**
    * Event name
    * example: "User Joined"
    */
-  event: TEvent;
+  event: TOptions['event'];
 
   /**
    * Event description

--- a/src/types/publish.ts
+++ b/src/types/publish.ts
@@ -1,24 +1,24 @@
 /**
  * Options for publishing LogSnag events
  */
-export interface PublishOptions {
+export interface PublishOptions <TProject = string, TChannel = string, TEvent = string> {
   /**
    * Project name
    * example: "my-saas"
    */
-  project: string;
+  project: TProject;
 
   /**
    * Channel name
    * example: "waitlist"
    */
-  channel: string;
+  channel: TChannel;
 
   /**
    * Event name
    * example: "User Joined"
    */
-  event: string;
+  event: TEvent;
 
   /**
    * Event description


### PR DESCRIPTION
### What's been changed?
 - Added generics to `PublishOptions` type
    - Added `TProject` to bind to `project` property (Default: `string`)
    - Added `TChannel ` to bind to `channel` property (Default: `string`)
    - Added `TEvent` to bind to `event` property (Default: `string`)

## Why?
This is just a small quality-of-life change to improve TypeScript support.
For example:
<img width="1006" alt="Screenshot 2022-06-23 at 10 44 03 pm" src="https://user-images.githubusercontent.com/4991309/175407702-f6ecb7f2-d355-4b6e-9097-3966bf267402.png">

