### PR TITLE
Export InsightOptions interface

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './publish'
+export * from './insight'


### PR DESCRIPTION
In the current build, the `insight.ts` types are not being exported thus not available for import. This fixes that.